### PR TITLE
feat/ 게시글 목록 조회 조건(정렬/검색/필터링/페이징)추가

### DIFF
--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
-from .models import Post
+from .models import Like, Post
 
 class PostSerializer(serializers.ModelSerializer):
     tags = serializers.SerializerMethodField()
+    likes = serializers.SerializerMethodField()
     
     def get_tags(self, obj):
         hashtag_list = []
@@ -10,9 +11,12 @@ class PostSerializer(serializers.ModelSerializer):
             hashtag_list.append('#' + tag.name)
         return hashtag_list
     
+    def get_likes(self, obj):
+        return Like.objects.filter(post=obj.id).count()
+    
     class Meta:
         model = Post
-        fields = ['id', 'writer', 'title', 'content', 'tags', 'views', 'created_date', 'updated_date', 'is_active']
+        fields = ['id', 'writer', 'title', 'content', 'tags', 'views', 'likes', 'created_date', 'updated_date', 'is_active']
         extra_kwargs = {
             'content': {'write_only': True},
         }

--- a/posts/service/post_services.py
+++ b/posts/service/post_services.py
@@ -1,4 +1,4 @@
-from django.db.models import Q
+from django.db.models import Count, Q
 from posts.serializers import PostSerializer, PostDetailSerializer
 from posts.models import Like, Post
 
@@ -15,8 +15,10 @@ def read_posts(order_by, reverse):
         reverse = '-'
     elif reverse == 0:
         reverse = ''
-        
-    posts = Post.objects.all().order_by(reverse + order_by)
+    if order_by == 'created_date' or order_by == 'views': 
+        posts = Post.objects.all().order_by(reverse + order_by)
+    elif order_by == 'likes':
+        posts = Post.objects.all().annotate(like_count=Count('like')).order_by(reverse + 'like_count')
     return posts
 
 def search_posts(posts, search):

--- a/posts/service/post_services.py
+++ b/posts/service/post_services.py
@@ -46,7 +46,23 @@ def filtering_posts(posts, tags):
     for tag in tags:
         posts = posts.filter(tags__name=tag)
     return posts
+
+def pagination_posts(posts, page_size, page):
+    """
+    Args:
+        posts : 정렬, 검색, 필터링 된 게시글
+        page_size : 한 페이지에 보여지는 게시글 수
+        page : 보고자하는 페이지
+
+    Returns:
+        PostSerializer
+    """
+    start_post = page_size * (page-1)
+    end_post = page * page_size
+    posts_serializer = PostSerializer(posts[start_post:end_post], many=True).data
+    return posts_serializer
     
+
 def create_post(create_data, user):
     """
     Args:

--- a/posts/service/post_services.py
+++ b/posts/service/post_services.py
@@ -1,12 +1,21 @@
 from posts.serializers import PostSerializer, PostDetailSerializer
 from posts.models import Like, Post
 
-def read_posts():
+def read_posts(order_by, reverse):
     """
+    Args:
+        order_by : 작성일, 조회수 중 1개
+        reverse : 1 > 내림차순  / 0 > 오름차순
     Returns:
         PostSerializer
     """
-    posts = Post.objects.all().order_by('-created_date')
+    
+    if reverse == 1:
+        reverse = '-'
+    elif reverse == 0:
+        reverse = ''
+        
+    posts = Post.objects.all().order_by(reverse + order_by)
     posts_serializer = PostSerializer(posts, many=True).data
     return posts_serializer
     

--- a/posts/service/post_services.py
+++ b/posts/service/post_services.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from posts.serializers import PostSerializer, PostDetailSerializer
 from posts.models import Like, Post
 
@@ -7,7 +8,7 @@ def read_posts(order_by, reverse):
         order_by : 작성일, 조회수 중 1개
         reverse : 1 > 내림차순  / 0 > 오름차순
     Returns:
-        PostSerializer
+        Post
     """
     
     if reverse == 1:
@@ -16,8 +17,21 @@ def read_posts(order_by, reverse):
         reverse = ''
         
     posts = Post.objects.all().order_by(reverse + order_by)
-    posts_serializer = PostSerializer(posts, many=True).data
-    return posts_serializer
+    return posts
+
+def search_posts(posts, search):
+    """
+    Args:
+        posts : 정렬이 완료된 게시글
+        search : 게시글 중 제목이나 내용에 해당 값이 들어있는 게시글만 반환
+
+    Returns:
+        Post
+    """
+    posts = posts.filter(
+        Q(title__icontains=search) | Q(content__icontains=search)
+    )
+    return posts
     
 def create_post(create_data, user):
     """

--- a/posts/service/post_services.py
+++ b/posts/service/post_services.py
@@ -32,6 +32,20 @@ def search_posts(posts, search):
         Q(title__icontains=search) | Q(content__icontains=search)
     )
     return posts
+
+def filtering_posts(posts, tags):
+    """
+    Args:
+        posts : 정렬과 검색이 된 게시글
+        tags : 게시글 중 해당 태그 값이 들어있는 게시글만 반환
+
+    Returns:
+        Post
+    """
+    tags = tags.split(',')
+    for tag in tags:
+        posts = posts.filter(tags__name=tag)
+    return posts
     
 def create_post(create_data, user):
     """

--- a/posts/views.py
+++ b/posts/views.py
@@ -5,6 +5,7 @@ from rest_framework.views import APIView
 from posts.models import Like
 from posts.service.post_services import (
     read_posts,
+    search_posts,
     create_post,
     edit_post,
     deactivate_post,
@@ -17,8 +18,10 @@ class PostView(APIView):
     def get(self, request):
         order_by = self.request.query_params.get('order_by', 'created_date')
         reverse = int(self.request.query_params.get('reverse', 1))
-        
+        search = self.request.query_params.get('search')
+
         posts = read_posts(order_by, reverse)
+        posts = search_posts(posts, search)
         return Response(posts, status=status.HTTP_200_OK)
     
     def post(self, request):

--- a/posts/views.py
+++ b/posts/views.py
@@ -7,6 +7,7 @@ from posts.service.post_services import (
     read_posts,
     search_posts,
     filtering_posts,
+    pagination_posts,
     create_post,
     edit_post,
     deactivate_post,
@@ -21,10 +22,13 @@ class PostView(APIView):
         reverse = int(self.request.query_params.get('reverse', 1))
         search = self.request.query_params.get('search')
         tags = self.request.query_params.get('tags')
-
+        page_size = int(self.request.query_params.get('page_size', 10))
+        page = int(self.request.query_params.get('page', 1))
+        
         posts = read_posts(order_by, reverse)
         posts = search_posts(posts, search)
         posts = filtering_posts(posts, tags)
+        posts = pagination_posts(posts, page_size, page)
         return Response(posts, status=status.HTTP_200_OK)
     
     def post(self, request):

--- a/posts/views.py
+++ b/posts/views.py
@@ -15,7 +15,10 @@ from posts.service.post_services import (
 
 class PostView(APIView):
     def get(self, request):
-        posts = read_posts()
+        order_by = self.request.query_params.get('order_by', 'created_date')
+        reverse = int(self.request.query_params.get('reverse', 1))
+        
+        posts = read_posts(order_by, reverse)
         return Response(posts, status=status.HTTP_200_OK)
     
     def post(self, request):

--- a/posts/views.py
+++ b/posts/views.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from posts.models import Like
 from posts.service.post_services import (
     read_posts,
     create_post,
@@ -39,11 +40,11 @@ class PostDetailView(APIView):
         post = read_detail_post(post_id)
         return Response(post, status=status.HTTP_200_OK)
 
-
 class LikeView(APIView):
     def post(self, request, post_id):
+        like_count = Like.objects.filter(post=post_id).count()
         if like_post(request.user, post_id):
-            return Response({'detail': '좋아요 했습니다'}, status=status.HTTP_200_OK)
+            return Response({'detail': '좋아요 했습니다', 'like_count': like_count}, status=status.HTTP_200_OK)
         return Response({'detail': '좋아요를 취소했습니다'}, status=status.HTTP_200_OK)
         
         

--- a/posts/views.py
+++ b/posts/views.py
@@ -6,6 +6,7 @@ from posts.models import Like
 from posts.service.post_services import (
     read_posts,
     search_posts,
+    filtering_posts,
     create_post,
     edit_post,
     deactivate_post,
@@ -19,9 +20,11 @@ class PostView(APIView):
         order_by = self.request.query_params.get('order_by', 'created_date')
         reverse = int(self.request.query_params.get('reverse', 1))
         search = self.request.query_params.get('search')
+        tags = self.request.query_params.get('tags')
 
         posts = read_posts(order_by, reverse)
         posts = search_posts(posts, search)
+        posts = filtering_posts(posts, tags)
         return Response(posts, status=status.HTTP_200_OK)
     
     def post(self, request):

--- a/posts/views.py
+++ b/posts/views.py
@@ -55,8 +55,8 @@ class PostDetailView(APIView):
 
 class LikeView(APIView):
     def post(self, request, post_id):
-        like_count = Like.objects.filter(post=post_id).count()
         if like_post(request.user, post_id):
+            like_count = Like.objects.filter(post=post_id).count()
             return Response({'detail': '좋아요 했습니다', 'like_count': like_count}, status=status.HTTP_200_OK)
         return Response({'detail': '좋아요를 취소했습니다'}, status=status.HTTP_200_OK)
         


### PR DESCRIPTION
<br>
<h1>게시글 목록 기능 추가</h1>

- 정렬 
  - (default: 작성일,  / 작성일, 좋아요 수, 조회수 중 1개 만 선택가능)
  - 오름차순, 내림차순 두가지를 구현
- 검색
  - 해당 키워드가 문자열 중 포함 된 데이터 검색
- 필터링
  - 지정한 해시태그를 포함한 게시물을 필터링
- 페이징
  - 사용자는 1 페이지 당 게시글 수를 조정할 수 있습니다. (default: 10건)

<img width="807" alt="스크린샷 2022-10-03 오후 5 25 35" src="https://user-images.githubusercontent.com/104303285/193538989-23cccd47-3b3c-4124-9189-55afa68289f3.png">
